### PR TITLE
Add Android.bp to support inline building

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,21 @@
+cc_binary {
+    name: "ih8sn",
+    init_rc: ["ih8sn.rc"],
+
+    local_include_dirs: [
+        "aosp/bionic/libc",
+        "aosp/bionic/libc/async_safe/include",
+        "aosp/bionic/libc/system_properties/include",
+        "aosp/system/core/base/include",
+        "aosp/system/core/property_service/libpropertyinfoparser/include",
+    ],
+
+    srcs: [
+        "aosp/**/*.cpp",
+        "main.cpp",
+    ],
+
+    static_libs: [
+        "libasync_safe",
+    ],
+}

--- a/main.cpp
+++ b/main.cpp
@@ -34,7 +34,7 @@ std::map<std::string, std::string> load_config() {
     return config;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc __unused, char *argv[] __unused) {
     if (__system_properties_init()) {
         return -1;
     }


### PR DESCRIPTION
* Just another build option for those that want it.

* Device tree is responsible for installing the target specific
  conf to /system/etc.