### PR TITLE
Add circumvention of OnePlus' oem unlock counter by @osm0sis

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -139,6 +139,7 @@ int main(int argc __unused, char *argv[] __unused) {
     property_override("ro.boot.verifiedbootstate", "green");
     property_override("ro.boot.veritymode", "enforcing");
     property_override("ro.boot.warranty_bit", "0");
+    property_override("ro.is_ever_orange", "0");
     property_override("ro.warranty_bit", "0");
 
     return 0;


### PR DESCRIPTION
Adaptation for commit [d2676e1@kdrag0n/safetynet-fix](https://github.com/kdrag0n/safetynet-fix/commit/d2676e12327bf47c8d8fd8de3fdbedaa0a53a39c), authored by @osm0sis. 
Original commit message:
> - I recently discovered `ro.is_ever_orange` on OOS 11, which gets set roughly 32 seconds after boot completed and is equal to the number of times a device has ever been `fastboot oem unlock`ed
> - a fresh MSM (i.e. factory locked device) has it set to 0, and using system.prop to set it to 0 earlier in the boot seems to keep it set to 0 instead of the real unlock count
> - I haven't seen this exploited anywhere, though I presume it exists for a reason, so probably good to manage it as well