### PR TITLE
Split prop spoofing into two stages: init and boot_completed

### DIFF
--- a/ih8sn.rc
+++ b/ih8sn.rc
@@ -1,3 +1,7 @@
+on init
+    exec u:r:su:s0 root root -- /system/bin/ih8sn init
+    exec u:r:sysinit:s0 root root -- /system/bin/ih8sn init
+
 on property:sys.boot_completed=1
-    exec u:r:su:s0 root root -- /system/bin/ih8sn
-    exec u:r:sysinit:s0 root root -- /system/bin/ih8sn
+    exec u:r:su:s0 root root -- /system/bin/ih8sn boot_completed
+    exec u:r:sysinit:s0 root root -- /system/bin/ih8sn boot_completed

--- a/main.cpp
+++ b/main.cpp
@@ -34,10 +34,17 @@ std::map<std::string, std::string> load_config() {
     return config;
 }
 
-int main(int argc __unused, char *argv[] __unused) {
+int main(int argc, char *argv[]) {
     if (__system_properties_init()) {
         return -1;
     }
+
+    if (argc != 2) {
+        return -1;
+    }
+
+    const auto is_init_stage = strcmp(argv[1], "init") == 0;
+    const auto is_boot_completed_stage = strcmp(argv[1], "boot_completed") == 0;
 
     const auto config = load_config();
     const auto build_fingerprint = config.find("BUILD_FINGERPRINT");
@@ -49,7 +56,7 @@ int main(int argc __unused, char *argv[] __unused) {
     const auto debuggable = config.find("DEBUGGABLE");
     const auto product_name = config.find("PRODUCT_NAME");
 
-    if (build_fingerprint != config.end()) {
+    if (is_init_stage && build_fingerprint != config.end()) {
         for (const auto &prop : {
             "ro.bootimage.build.fingerprint",
             "ro.build.fingerprint",
@@ -64,7 +71,7 @@ int main(int argc __unused, char *argv[] __unused) {
         }
     }
 
-    if (build_tags != config.end()) {
+    if (is_init_stage && build_tags != config.end()) {
         for (const auto &prop : {
             "ro.bootimage.build.tags",
             "ro.build.tags",
@@ -79,7 +86,7 @@ int main(int argc __unused, char *argv[] __unused) {
         }
     }
 
-    if (build_type != config.end()) {
+    if (is_init_stage && build_type != config.end()) {
         for (const auto &prop : {
             "ro.bootimage.build.type",
             "ro.build.type",
@@ -94,7 +101,7 @@ int main(int argc __unused, char *argv[] __unused) {
         }
     }
 
-    if (build_version_release != config.end()) {
+    if (is_boot_completed_stage && build_version_release != config.end()) {
         for (const auto &prop : {
             "ro.bootimage.build.version.release",
             "ro.build.version.release",
@@ -116,16 +123,16 @@ int main(int argc __unused, char *argv[] __unused) {
         }
     }
 
-    if (build_description != config.end()) {
+    if (is_init_stage && build_description != config.end()) {
         property_override("ro.build.description", build_description->second.c_str());
     }
 
-    if (build_security_patch_date != config.end()) {
+    if (is_boot_completed_stage && build_security_patch_date != config.end()) {
         property_override("ro.build.version.security_patch",
                 build_security_patch_date->second.c_str());
     }
 
-    if (debuggable != config.end()) {
+    if (is_init_stage && debuggable != config.end()) {
         property_override("ro.debuggable", debuggable->second.c_str());
     }
 


### PR DESCRIPTION
This effectively allows us to spoof *safe* props before zygote is up.